### PR TITLE
Fixed permission of cache and config directories

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func LoadConfig() (*Config, error) {
     }
     configDir = filepath.Join(configDir, ".config")
   }
-  os.MkdirAll(configDir, os.ModeDir)
+  os.MkdirAll(configDir, 0755)
 
   configFile := filepath.Join(configDir, "superhighway84.toml")
 
@@ -102,7 +102,7 @@ func (cfg *Config) Setup() (error) {
   if strings.TrimSpace(cfg.CachePath) == "" {
     cfg.CachePath = defaultCachePath
   }
-  os.MkdirAll(filepath.Dir(cfg.CachePath), os.ModeDir)
+  os.MkdirAll(filepath.Dir(cfg.CachePath), 0755)
 
   defaultLogfile := filepath.Join(cacheDir, "superhighway84.log")
   fmt.Printf("Logfile path [%s]: ", defaultLogfile)


### PR DESCRIPTION
If SH84 creates the DB cache dir OR the config dir, then they get created with wonky permissions, and SH84 fails to start.

I bumped into this while testing SH84 for the first time.
In particular, I was trying to write anything outside of the repository folder
```
      export IPFS_PATH=$PWD/.ipfs-sh84
      export XDG_CACHE_HOME=$PWD/.xdg-cache
      export XDG_CONFIG_HOME=$PWD/.config
```

I was greeted by this error on launch:

```
2021/12/29 10:11:24 couldn't open sink "/Users/mprime/code/misc/superhighway84.git/.xdg-cache/superhighway84.log": open /Users/mprime/code/misc/superhighway84.git/.xdg-cache/superhighway84.log: permission denied
panic: couldn't open sink "/Users/mprime/code/misc/superhighway84.git/.xdg-cache/superhighway84.log": open /Users/mprime/code/misc/superhighway84.git/.xdg-cache/superhighway84.log: permission denied

goroutine 1 [running]:
log.Panicln(0xc000d8ff50, 0x1, 0x1)
	/nix/store/pzqpv155khkrp7nai0mbsc32zxlp9s0k-go-1.16.2/share/go/src/log/log.go:368 +0xae
main.main()
	/Users/mprime/code/misc/superhighway84.git/superhighway84.go:59 +0x1f3
```

Uh? Can't open a log file?

```
$ ls -la 
(...)
drwxr-xr-x  8 mprime staff      256 Dec 29 09:59 .ipfs-sh84
d---------  2 mprime staff       64 Dec 29 10:09 .xdg-cache
```

I'm not a Golang ninja, but this seems to be the expected result of `os.MkdirAll(path, os.ModeDir)`.

Here's a simple repro if you want to try on your system (I tried both macOS and Unbuntu with the same end result: directory is created with permissions `000`).

```
package main

import (
  "os"
)

func main() {
  os.MkdirAll("./a-dir", os.ModeDir)
}
```

Switching to `0755` seems reasonable. I see you have other file permissions embedded in the same file (e.g.,: `os.OpenFile(configFile, os.O_CREATE|os.O_RDWR, 0644)`) so I just hardcoded it.