### PR TITLE
Refactor main screen layout using nested grids

### DIFF
--- a/tui/mainscreen.go
+++ b/tui/mainscreen.go
@@ -132,19 +132,29 @@ func(t *TUI) NewMainscreen() (*Mainscreen) {
   mainscreen.Footer.SetBorder(false).
     SetBorderPadding(0, 0, 1, 1)
 
-	mainscreen.Canvas = tview.NewGrid().
-		SetRows(5, 0, 0, 1).
-		SetColumns(30, 0, 14).
-		SetBorders(false).
-		AddItem(mainscreen.Header, 0, 0, 1, 2, 0, 0, false).
-    AddItem(mainscreen.Stats,  0, 2, 1, 1, 0, 0, false).
-		AddItem(mainscreen.Info,   3, 0, 1, 1, 0, 0, false).
-		AddItem(mainscreen.Footer, 3, 1, 1, 2, 0, 0, false)
+  topRowGrid := tview.NewGrid().
+    SetColumns(30, 0, 14).
+    AddItem(mainscreen.Header, 0, 0, 1, 2, 0, 0, false).
+    AddItem(mainscreen.Stats,  0, 2, 1, 1, 0, 0, false)
 
-	mainscreen.Canvas.
-    AddItem(mainscreen.Groups,   1, 0, 2, 1, 0, 0, false).
-		AddItem(mainscreen.Articles, 1, 1, 1, 2, 0, 0, false).
-		AddItem(mainscreen.Preview,  2, 1, 1, 2, 0, 0, false)
+  midRowGrid := tview.NewGrid().
+    SetColumns(-1, -5). // Group takes ~1/5 of the horizontal space available
+    SetRows(-2, -3). // Preview is ~1/3 bigger than Articles
+    AddItem(mainscreen.Groups,   0, 0, 2, 1, 0, 0, false).
+    AddItem(mainscreen.Articles, 0, 1, 1, 1, 0, 0, false).
+    AddItem(mainscreen.Preview,  1, 1, 1, 1, 0, 0, false)
+
+  bottomRowGrid := tview.NewGrid().
+    SetColumns(5, 0, 0).
+    AddItem(mainscreen.Info,   0, 0, 1, 1, 0, 0, false).
+    AddItem(mainscreen.Footer, 0, 1, 1, 2, 0, 0, false)
+
+  mainscreen.Canvas = tview.NewGrid().
+    SetRows(5, 0, 1).
+    SetBorders(false).
+    AddItem(topRowGrid,    0, 0, 1, 1, 0, 0, false).
+    AddItem(midRowGrid,    1, 0, 1, 1, 0, 0, false).
+    AddItem(bottomRowGrid, 2, 0, 1, 1, 0, 0, false)
 
   mainscreen.ArticlesListView = mainscreen.T.Config.ArticlesListView
   return mainscreen


### PR DESCRIPTION
Simplify the main layout by creating sub-grids in each row of the 
existing grid. This allows each row to have independent column layout.

Within each grid the placement is straighforward and can be more easily 
adjusted.

One visible change is that the main pane sizes are now relative, so they 
adjust based on the terminal width and height (whereas before they were 
fixed regardless of terminal size).

## Small window

### Before
![before-small](https://user-images.githubusercontent.com/6885259/150927359-e2683114-670b-4f16-8ddb-052bf583ff6f.png)

### After
![after-small](https://user-images.githubusercontent.com/6885259/150927366-90f03cd5-92d7-4b15-ae2b-eb7f34b58c87.png)

## Large window

### Before
![before-large](https://user-images.githubusercontent.com/6885259/150927365-d3267e2c-5f4c-4258-bd15-9236281cadd6.png)

### After
![after-large](https://user-images.githubusercontent.com/6885259/150927367-dcf63706-16aa-418f-8a31-cec38ab66011.png)



