### PR TITLE
 [ ⚠️ Proof of concept / Work in progress] RSS server

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"time"
+
+	"log"
+
+	"github.com/mrusme/superhighway84/cache"
+	"github.com/mrusme/superhighway84/config"
+	"github.com/mrusme/superhighway84/database"
+	"github.com/mrusme/superhighway84/models"
+	"go.uber.org/zap"
+)
+
+const LISTEN_ADDR_AND_PORT = ":8080"
+
+func NewLogger(filename string) (*zap.Logger, error) {
+  if runtime.GOOS == "windows" {
+    zap.RegisterSink("winfile", func(u *url.URL) (zap.Sink, error) {
+      return os.OpenFile(u.Path[1:], os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+    })
+  }
+
+  cfg := zap.NewProductionConfig()
+  if runtime.GOOS == "windows" {
+    cfg.OutputPaths = []string{
+      "stdout",
+      "winfile:///" + filename,
+    }
+  } else {
+    cfg.OutputPaths = []string{
+      filename,
+    }
+  }
+  return cfg.Build()
+}
+
+// Apparently there's no `min` for ints in golang
+// https://stackoverflow.com/questions/27516387/what-is-the-correct-way-to-find-the-min-between-two-integers-in-go
+func minInt(x, y int) int {
+    if x < y {
+        return x
+    }
+    return y
+}
+
+func main() {
+  ctx, cancel := context.WithCancel(context.Background())
+  defer cancel()
+
+  log.Println("loading configuration ...")
+  cfg, err := config.LoadConfig()
+  if err != nil {
+    log.Panicln(err)
+  }
+  if cfg.WasSetup() == false {
+    cfg.Setup()
+  }
+
+  log.Println("initializing logger ...")
+  logger, err := NewLogger(cfg.Logfile)
+  if err != nil {
+    log.Panicln(err)
+  }
+
+  log.Println("initializing cache ...")
+  cch, err := cache.NewCache(cfg.ProgramCachePath)
+  if err != nil {
+    log.Panicln(err)
+  }
+  defer cch.Close()
+
+  var articles []*models.Article
+  var articlesRoots []*models.Article
+
+	log.Println(articles)
+	log.Println(articlesRoots)
+
+	log.Println("Creating DB")
+  db, err := database.NewDatabase(ctx, cfg.ConnectionString, cfg.DatabaseCachePath, cch, logger)
+  if err != nil {
+    log.Panicln(err)
+  }
+  defer db.Disconnect()
+
+	log.Println("Connecting")
+  err = db.Connect(func(address string) {
+    articles, articlesRoots, _ = db.ListArticles()
+		log.Printf("Pre-loaded %d articles, %d roots", len(articles), len(articlesRoots))
+  })
+  if err != nil {
+    log.Panicln(err)
+  }
+
+	log.Println("Connected")
+
+	// ☠️  This is Proof of concept code.
+	// It's ugly, it's buggy and it's very much not thread-safe!
+
+	go func () {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(30 * time.Second):
+				log.Println("Refreshing...")
+				articles, articlesRoots, _ = db.ListArticles()
+				log.Printf("Loaded %d articles, %d roots", len(articles), len(articlesRoots))
+			}
+		}
+	}()
+
+	createResponse := func(w http.ResponseWriter, articles []*models.Article) {
+
+		fmt.Fprintf(w, "<RSS HEADER>\n")
+
+		numArticles := minInt(len(articles), 10)
+
+		if numArticles > 0 {
+			for i, article := range articles[0:numArticles] {
+				fmt.Fprintf(w, "[%d] %s\n", i, article.Subject)
+				fmt.Fprintf(w, "   from:%s in:%s\n", article.From, article.Newsgroup)
+			}
+		}
+
+		fmt.Fprintf(w, "<RSS FOOTER>\n")
+	}
+
+	articlesHandler := func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("/%s", r.URL.Path[1:])
+		createResponse(w, articlesRoots)
+	}
+
+	commentsHandler := func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("/%s", r.URL.Path[1:])
+		createResponse(w, articles)
+	}
+
+	http.HandleFunc("/rss/articles", articlesHandler)
+	http.HandleFunc("/rss/comments", commentsHandler)
+
+	log.Printf("Listening on %s", LISTEN_ADDR_AND_PORT)
+	log.Fatal(http.ListenAndServe(LISTEN_ADDR_AND_PORT, nil))
+}

--- a/rss/rss.go
+++ b/rss/rss.go
@@ -1,0 +1,98 @@
+package rss
+
+import (
+  "fmt"
+  "io"
+  "github.com/mrusme/superhighway84/models"
+)
+
+// ☠️  This is Proof of concept code!
+// For example, it's currently composing the feed for each request, which doesn't
+// make sense given how (not) frequently the articles update.
+
+type FeedOptions struct {
+  MaxArticles    int
+}
+
+type Feed struct {
+  Options     FeedOptions
+  Articles    []*models.Article
+}
+
+func NewFeedOptions() (FeedOptions) {
+  return FeedOptions{10}
+}
+
+// Apparently there's no `min` for ints in golang
+// https://stackoverflow.com/questions/27516387/what-is-the-correct-way-to-find-the-min-between-two-integers-in-go
+func minInt(x, y int) int {
+    if x < y {
+        return x
+    }
+    return y
+}
+
+func NewFeed(articles []*models.Article, feedOptions FeedOptions) (Feed) {
+
+  numArticles := minInt(len(articles), feedOptions.MaxArticles)
+  articlesSlice := articles[0:numArticles]
+
+  return Feed{
+    Options: feedOptions,
+    Articles: articlesSlice,
+  }
+}
+
+const header = `
+<rss version="2.0">
+  <channel>
+    <title>%s</title>
+    <link>%s</link>
+    <description>%s</description>
+    <language>%s</language>
+    <pubDate>%s</pubDate>
+    <lastBuildDate>%s</lastBuildDate>
+    <docs>%s</docs>
+    <generator>%s</generator>
+`
+
+const footer = `
+  </channel>
+</rss>
+`
+
+const item = `
+    <item>
+      <title>%s</title>
+      <link>%s</link>
+      <description>%s</description>
+      <pubDate>%s</pubDate>
+      <guid>%s</guid>
+    </item>
+`
+
+func (feed *Feed) Write(w io.Writer) (error) {
+
+  title := "Superhighway84"
+  link := "https://xn--gckvb8fzb.com/superhighway84/"
+  description := "USENET-INSPIRED DECENTRALIZED INTERNET DISCUSSION SYSTEM"
+  language := "en-us"
+  pubDate := "Tue, 10 Jun 2003 04:00:00 GMT"
+  buildDate := "Tue, 10 Jun 2003 09:41:01 GMT"
+  docsLink := "http://blogs.law.harvard.edu/tech/rss"
+  generator := "Superhighway84 RSS Generator"
+  fmt.Fprintf(w, header, title, link, description, language, pubDate, buildDate, docsLink, generator)
+
+  for _, article := range feed.Articles {
+    title := article.Subject
+    link := fmt.Sprintf("superhighway84://%s", article.ID)
+    description := fmt.Sprintf("Posted by %s in %s<br>%d replies<br>%s", article.From, article.Newsgroup, len(article.Replies), article.Body)
+    pubDate := "Tue, 03 Jun 2003 09:39:21 GMT"
+    guid := article.ID
+    fmt.Fprintf(w, item, title, link, description, pubDate, guid)
+  }
+
+  fmt.Fprintf(w, footer)
+
+  return nil
+}


### PR DESCRIPTION
This creates a 'server mode' SH84 that does two things:

 - Work as headless peer to serve IPFS content
 - Serves an RSS feed of latest articles (i.e. roots) or comments (i.e. all articles)

I intend to deploy this on my own server and add the feed URL to my newsreader, so I can keep an eye on posts without firing up SH84.

It's not actually serving RSS right now, but you can try it with:

```
$ curl localhost:8080/rss/articles
$ curl localhost:8080/rss/comments
```



